### PR TITLE
fix: read username from secret for git authentication

### DIFF
--- a/pkg/syncer/git.go
+++ b/pkg/syncer/git.go
@@ -158,8 +158,13 @@ func (s *Syncer) syncSite(ctx context.Context, site *staticSiteData) error {
 		if err != nil {
 			return fmt.Errorf("failed to get git credentials: %w", err)
 		}
+		// Get username from secret, default to "git" if not present
+		username, _ := s.getSecretValue(ctx, site.Namespace, site.SecretRef.Name, "username")
+		if username == "" {
+			username = "git"
+		}
 		auth = &http.BasicAuth{
-			Username: "git", // Username doesn't matter for tokens
+			Username: username,
 			Password: password,
 		}
 	}


### PR DESCRIPTION
## Summary

- Fixes syncer hardcoding git username to "git", which breaks GitLab deploy tokens
- Now reads username from secret's "username" key, falling back to "git" if not present

## Test plan

- [x] Unit tests pass
- [ ] Deploy with GitLab deploy token and verify authentication works

Fixes #2