### PR TITLE
fix: use ExternalName service for cross-namespace nginx access

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ The operator accepts these flags:
 |------|---------|-------------|
 | `--pages-domain` | `pages.kup6s.com` | Base domain for auto-generated subdomains |
 | `--cluster-issuer` | `letsencrypt-prod` | cert-manager ClusterIssuer name |
+| `--nginx-namespace` | `kup6s-pages` | Namespace where nginx service runs |
+| `--nginx-service-name` | `kup6s-pages-nginx` | Name of the nginx service |
 | `--metrics-bind-address` | `:8080` | Metrics endpoint |
 | `--health-probe-bind-address` | `:8081` | Health probe endpoint |
 

--- a/charts/kup6s-pages/templates/clusterrole-operator.yaml
+++ b/charts/kup6s-pages/templates/clusterrole-operator.yaml
@@ -27,6 +27,11 @@ rules:
     resources: ["certificates"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
+  # Core Services (for nginx proxy ExternalName services)
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
   # Events
   - apiGroups: [""]
     resources: ["events"]

--- a/charts/kup6s-pages/templates/deployment-operator.yaml
+++ b/charts/kup6s-pages/templates/deployment-operator.yaml
@@ -39,6 +39,7 @@ spec:
             - --pages-domain={{ .Values.operator.pagesDomain }}
             - --cluster-issuer={{ .Values.operator.clusterIssuer }}
             - --nginx-namespace={{ include "kup6s-pages.namespace" . }}
+            - --nginx-service-name={{ include "kup6s-pages.fullname" . }}-nginx
             - --metrics-bind-address={{ .Values.operator.metricsBindAddress }}
             - --health-probe-bind-address={{ .Values.operator.healthProbeBindAddress }}
             {{- range .Values.operator.extraArgs }}

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -34,12 +34,14 @@ func main() {
 	var pagesDomain string
 	var clusterIssuer string
 	var nginxNamespace string
+	var nginxServiceName string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address for metrics endpoint")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address for health probes")
 	flag.StringVar(&pagesDomain, "pages-domain", "pages.kup6s.com", "Base domain for auto-generated URLs")
 	flag.StringVar(&clusterIssuer, "cluster-issuer", "letsencrypt-prod", "cert-manager ClusterIssuer name")
 	flag.StringVar(&nginxNamespace, "nginx-namespace", "kup6s-pages", "Namespace where nginx service runs")
+	flag.StringVar(&nginxServiceName, "nginx-service-name", "kup6s-pages-nginx", "Name of the nginx service in the system namespace")
 	
 	opts := zap.Options{Development: true}
 	opts.BindFlags(flag.CommandLine)
@@ -69,12 +71,13 @@ func main() {
 
 	// Register controller
 	if err = (&controller.StaticSiteReconciler{
-		Client:         mgr.GetClient(),
-		DynamicClient:  dynamicClient,
-		Recorder:       mgr.GetEventRecorderFor("staticsite-controller"),
-		PagesDomain:    pagesDomain,
-		ClusterIssuer:  clusterIssuer,
-		NginxNamespace: nginxNamespace,
+		Client:           mgr.GetClient(),
+		DynamicClient:    dynamicClient,
+		Recorder:         mgr.GetEventRecorderFor("staticsite-controller"),
+		PagesDomain:      pagesDomain,
+		ClusterIssuer:    clusterIssuer,
+		NginxNamespace:   nginxNamespace,
+		NginxServiceName: nginxServiceName,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "StaticSite")
 		os.Exit(1)

--- a/docs/CONCEPT.md
+++ b/docs/CONCEPT.md
@@ -138,12 +138,14 @@ spec:
       middlewares:
         - name: customer-website-prefix
       services:
-        - name: static-sites-nginx
-          namespace: kup6s-pages
+        - name: pages-nginx-proxy  # ExternalName service pointing to nginx
+          namespace: pages         # Same namespace as IngressRoute
           port: 80
   tls:
     secretName: customer-website-tls
 ```
+
+Note: The IngressRoute references a local `pages-nginx-proxy` ExternalName service (created by the operator) instead of the nginx service directly. This is required because Traefik doesn't allow cross-namespace service references by default.
 
 **cert-manager Certificate** (only for custom domains)
 ```yaml

--- a/pkg/controller/staticsite_test.go
+++ b/pkg/controller/staticsite_test.go
@@ -40,11 +40,13 @@ func TestReconcile_NewSite(t *testing.T) {
 		Build()
 
 	r := &StaticSiteReconciler{
-		Client:        fakeClient,
-		DynamicClient: &fakeDynamicClient{},
-		Recorder:      record.NewFakeRecorder(10),
-		PagesDomain:   "pages.kup6s.com",
-		ClusterIssuer: "letsencrypt-prod",
+		Client:           fakeClient,
+		DynamicClient:    &fakeDynamicClient{},
+		Recorder:         record.NewFakeRecorder(10),
+		PagesDomain:      "pages.kup6s.com",
+		ClusterIssuer:    "letsencrypt-prod",
+		NginxNamespace:   "kup6s-pages",
+		NginxServiceName: "kup6s-pages-nginx",
 	}
 
 	req := ctrl.Request{
@@ -108,11 +110,13 @@ func TestReconcile_CustomDomain(t *testing.T) {
 		Build()
 
 	r := &StaticSiteReconciler{
-		Client:        fakeClient,
-		DynamicClient: &fakeDynamicClient{},
-		Recorder:      record.NewFakeRecorder(10),
-		PagesDomain:   "pages.kup6s.com",
-		ClusterIssuer: "letsencrypt-prod",
+		Client:           fakeClient,
+		DynamicClient:    &fakeDynamicClient{},
+		Recorder:         record.NewFakeRecorder(10),
+		PagesDomain:      "pages.kup6s.com",
+		ClusterIssuer:    "letsencrypt-prod",
+		NginxNamespace:   "kup6s-pages",
+		NginxServiceName: "kup6s-pages-nginx",
 	}
 
 	req := ctrl.Request{
@@ -148,10 +152,12 @@ func TestReconcile_NotFound(t *testing.T) {
 		Build()
 
 	r := &StaticSiteReconciler{
-		Client:        fakeClient,
-		DynamicClient: &fakeDynamicClient{},
-		Recorder:      record.NewFakeRecorder(10),
-		PagesDomain:   "pages.kup6s.com",
+		Client:           fakeClient,
+		DynamicClient:    &fakeDynamicClient{},
+		Recorder:         record.NewFakeRecorder(10),
+		PagesDomain:      "pages.kup6s.com",
+		NginxNamespace:   "kup6s-pages",
+		NginxServiceName: "kup6s-pages-nginx",
 	}
 
 	req := ctrl.Request{
@@ -194,10 +200,12 @@ func TestReconcile_Deletion(t *testing.T) {
 		Build()
 
 	r := &StaticSiteReconciler{
-		Client:        fakeClient,
-		DynamicClient: &fakeDynamicClient{},
-		Recorder:      record.NewFakeRecorder(10),
-		PagesDomain:   "pages.kup6s.com",
+		Client:           fakeClient,
+		DynamicClient:    &fakeDynamicClient{},
+		Recorder:         record.NewFakeRecorder(10),
+		PagesDomain:      "pages.kup6s.com",
+		NginxNamespace:   "kup6s-pages",
+		NginxServiceName: "kup6s-pages-nginx",
 	}
 
 	req := ctrl.Request{
@@ -290,9 +298,9 @@ func TestFinalizerName(t *testing.T) {
 	}
 }
 
-func TestNginxServiceConfig(t *testing.T) {
-	if nginxServiceName != "static-sites-nginx" {
-		t.Errorf("nginxServiceName = %q, want %q", nginxServiceName, "static-sites-nginx")
+func TestNginxProxyServiceName(t *testing.T) {
+	if nginxProxyServiceName != "pages-nginx-proxy" {
+		t.Errorf("nginxProxyServiceName = %q, want %q", nginxProxyServiceName, "pages-nginx-proxy")
 	}
 }
 
@@ -468,11 +476,13 @@ func TestReconcile_PathPrefix(t *testing.T) {
 		Build()
 
 	r := &StaticSiteReconciler{
-		Client:        fakeClient,
-		DynamicClient: &fakeDynamicClient{},
-		Recorder:      record.NewFakeRecorder(10),
-		PagesDomain:   "pages.kup6s.com",
-		ClusterIssuer: "letsencrypt-prod",
+		Client:           fakeClient,
+		DynamicClient:    &fakeDynamicClient{},
+		Recorder:         record.NewFakeRecorder(10),
+		PagesDomain:      "pages.kup6s.com",
+		ClusterIssuer:    "letsencrypt-prod",
+		NginxNamespace:   "kup6s-pages",
+		NginxServiceName: "kup6s-pages-nginx",
 	}
 
 	req := ctrl.Request{
@@ -529,11 +539,13 @@ func TestReconcile_PathPrefixValidationFails(t *testing.T) {
 		Build()
 
 	r := &StaticSiteReconciler{
-		Client:        fakeClient,
-		DynamicClient: &fakeDynamicClient{},
-		Recorder:      record.NewFakeRecorder(10),
-		PagesDomain:   "pages.kup6s.com",
-		ClusterIssuer: "letsencrypt-prod",
+		Client:           fakeClient,
+		DynamicClient:    &fakeDynamicClient{},
+		Recorder:         record.NewFakeRecorder(10),
+		PagesDomain:      "pages.kup6s.com",
+		ClusterIssuer:    "letsencrypt-prod",
+		NginxNamespace:   "kup6s-pages",
+		NginxServiceName: "kup6s-pages-nginx",
 	}
 
 	req := ctrl.Request{


### PR DESCRIPTION
## Summary

- Fixes cross-namespace service reference issue that caused 404 errors with Traefik IngressRoutes
- Creates ExternalName service (`pages-nginx-proxy`) in each StaticSite's namespace as DNS alias to nginx
- Makes nginx service name configurable via `--nginx-service-name` flag
- Adds cleanup logic to remove proxy service when last StaticSite is deleted from namespace

## Changes

| File | Description |
|------|-------------|
| `pkg/controller/staticsite.go` | Add `reconcileNginxProxyService()`, `cleanupOrphanedNginxProxyService()`, update IngressRoute service reference |
| `cmd/operator/main.go` | Add `--nginx-service-name` flag |
| `charts/kup6s-pages/templates/deployment-operator.yaml` | Pass nginx service name from Helm |
| `charts/kup6s-pages/templates/clusterrole-operator.yaml` | Add RBAC for Services |
| `pkg/controller/staticsite_test.go` | Update tests with new reconciler fields |

## Test plan

- [x] `go test ./...` passes
- [x] `go build ./...` succeeds
- [x] `helm lint charts/kup6s-pages` passes
- [x] `helm template` shows correct `--nginx-service-name` arg
- [ ] Deploy to cluster and verify IngressRoute works

Fixes #4