### PR TITLE
security: add authentication to syncer HTTP endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Both sites share the same TLS certificate. Requests to:
 | `lastSync` | Timestamp of last successful sync |
 | `lastCommit` | Short SHA of the last synced commit |
 | `url` | Full URL of the deployed site |
+| `syncToken` | Auto-generated token for API authentication |
 
 ### Check Status
 
@@ -273,7 +274,8 @@ For instant deployments on push, configure webhooks in your Git provider.
 |----------|-----|
 | Forgejo/Gitea | `https://webhook.pages.kup6s.com/webhook/forgejo` |
 | GitHub | `https://webhook.pages.kup6s.com/webhook/github` |
-| Manual trigger | `POST https://webhook.pages.kup6s.com/sync/{namespace}/{name}` |
+| Manual sync | `POST /sync/{namespace}/{name}` (requires `X-API-Key` header) |
+| Delete site | `DELETE /site/{namespace}/{name}` (requires `X-API-Key` header) |
 
 ### Setup Webhook Ingress
 
@@ -369,9 +371,13 @@ git clone https://git:YOUR_TOKEN@forgejo.example.com/org/repo.git
 
 ### Force re-sync
 
-Trigger a manual sync via webhook:
+Trigger a manual sync using the site's sync token:
 ```bash
-curl -X POST https://webhook.pages.kup6s.com/sync/pages/my-website
+# Get the sync token from the StaticSite status
+TOKEN=$(kubectl get staticsite my-website -n pages -o jsonpath='{.status.syncToken}')
+
+# Trigger sync with authentication
+curl -H "X-API-Key: $TOKEN" -X POST https://webhook.pages.kup6s.com/sync/pages/my-website
 ```
 
 ## Development

--- a/charts/kup6s-pages/crds/staticsites.pages.kup6s.com.yaml
+++ b/charts/kup6s-pages/crds/staticsites.pages.kup6s.com.yaml
@@ -102,6 +102,9 @@ spec:
                         type: string
                       message:
                         type: string
+                syncToken:
+                  type: string
+                  description: Token for authenticating /sync and /site API calls
       subresources:
         status: {}
       additionalPrinterColumns:

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -99,6 +99,11 @@ type StaticSiteStatus struct {
 	// Conditions for detailed status information
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+
+	// SyncToken for authenticating /sync and /site API calls
+	// Auto-generated on first reconcile
+	// +optional
+	SyncToken string `json:"syncToken,omitempty"`
 }
 
 // Phase describes the lifecycle status

--- a/pkg/controller/staticsite_test.go
+++ b/pkg/controller/staticsite_test.go
@@ -56,7 +56,7 @@ func TestReconcile_NewSite(t *testing.T) {
 		},
 	}
 
-	// Erster Reconcile: Finalizer hinzufügen
+	// First Reconcile: add finalizer
 	result, err := r.Reconcile(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Reconcile() error = %v", err)
@@ -65,13 +65,22 @@ func TestReconcile_NewSite(t *testing.T) {
 		t.Error("expected Requeue=true after adding finalizer")
 	}
 
-	// Zweiter Reconcile: Ressourcen erstellen
+	// Second Reconcile: generate sync token
+	result, err = r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if !result.Requeue {
+		t.Error("expected Requeue=true after generating sync token")
+	}
+
+	// Third Reconcile: create resources
 	result, err = r.Reconcile(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Reconcile() error = %v", err)
 	}
 
-	// Status prüfen
+	// Check status
 	updatedSite := &pagesv1.StaticSite{}
 	err = fakeClient.Get(context.Background(), req.NamespacedName, updatedSite)
 	if err != nil {
@@ -126,7 +135,14 @@ func TestReconcile_CustomDomain(t *testing.T) {
 		},
 	}
 
+	// First Reconcile: generate sync token
 	_, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	// Second Reconcile: create resources
+	_, err = r.Reconcile(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Reconcile() error = %v", err)
 	}
@@ -492,7 +508,14 @@ func TestReconcile_PathPrefix(t *testing.T) {
 		},
 	}
 
+	// First Reconcile: generate sync token
 	_, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+
+	// Second Reconcile: create resources
+	_, err = r.Reconcile(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Reconcile() error = %v", err)
 	}
@@ -555,7 +578,14 @@ func TestReconcile_PathPrefixValidationFails(t *testing.T) {
 		},
 	}
 
+	// First Reconcile: generate sync token
 	_, err := r.Reconcile(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v, want nil", err)
+	}
+
+	// Second Reconcile: validation fails, sets Error status
+	_, err = r.Reconcile(context.Background(), req)
 	if err != nil {
 		t.Fatalf("Reconcile() error = %v, want nil (error in status)", err)
 	}


### PR DESCRIPTION
## Summary

- Add per-site token authentication to `/sync` and `/site` API endpoints
- Each StaticSite auto-generates a unique `syncToken` in status
- Syncer validates `X-API-Key` header against the site's token
- Update DELETE endpoint to `/site/{namespace}/{name}` for consistency

## Changes

- `pkg/apis/v1alpha1/types.go`: Add `SyncToken` to status
- `pkg/controller/staticsite.go`: Generate token on first reconcile
- `pkg/syncer/server.go`: Add token validation for protected endpoints
- `charts/kup6s-pages/crds/`: Update CRD schema
- `README.md`: Document authentication requirements

## Test plan

- [x] `go test ./...` passes
- [x] `helm unittest` passes
- [ ] Deploy and verify syncToken is generated
- [ ] Test `curl -X POST /sync/default/mysite` returns 401
- [ ] Test `curl -H "X-API-Key: <token>" -X POST /sync/default/mysite` returns 200

Closes #6