### PR TITLE
security: make webhook secret mandatory when ingress enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,23 +279,29 @@ For instant deployments on push, configure webhooks in your Git provider.
 
 ### Setup Webhook Ingress
 
-Enable webhooks in your Helm values:
+Enable webhooks in your Helm values. **A webhook secret is required** for HMAC signature validation:
 
 ```yaml
 webhook:
   enabled: true
   domain: "webhook.pages.example.com"
   clusterIssuer: "letsencrypt-prod"
+  # Required: set a secret for HMAC validation
+  secret: "your-webhook-secret-here"
+  # Or reference an existing secret:
+  # secretRef:
+  #   name: "my-webhook-secret"
+  #   key: "webhook-secret"
 ```
 
-This creates the IngressRoute and Certificate automatically.
+This creates the IngressRoute and Certificate automatically. The same secret must be configured in your Git provider's webhook settings.
 
 ### Configure in Forgejo/Gitea
 
 1. Go to Repository → Settings → Webhooks → Add Webhook
 2. URL: `https://webhook.pages.kup6s.com/webhook/forgejo`
 3. Content Type: `application/json`
-4. Secret: (optional, for signature validation)
+4. Secret: Use the same secret configured in `webhook.secret`
 5. Events: Push events
 
 ### Configure in GitHub
@@ -303,7 +309,7 @@ This creates the IngressRoute and Certificate automatically.
 1. Go to Repository → Settings → Webhooks → Add webhook
 2. Payload URL: `https://webhook.pages.kup6s.com/webhook/github`
 3. Content type: `application/json`
-4. Secret: (optional, for signature validation)
+4. Secret: Use the same secret configured in `webhook.secret`
 5. Events: Just the push event
 
 ## Operator Configuration

--- a/charts/kup6s-pages/templates/_helpers.tpl
+++ b/charts/kup6s-pages/templates/_helpers.tpl
@@ -153,3 +153,24 @@ Webhook ClusterIssuer
 {{- define "kup6s-pages.webhook.clusterIssuer" -}}
 {{- default .Values.operator.clusterIssuer .Values.webhook.clusterIssuer }}
 {{- end }}
+
+{{/*
+Check if webhook secret is configured
+Returns true if either webhook.secret or webhook.secretRef.name is set
+*/}}
+{{- define "kup6s-pages.webhook.hasSecret" -}}
+{{- if or .Values.webhook.secret .Values.webhook.secretRef.name -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+Webhook secret name (for secretRef)
+*/}}
+{{- define "kup6s-pages.webhook.secretName" -}}
+{{- if .Values.webhook.secretRef.name -}}
+{{- .Values.webhook.secretRef.name -}}
+{{- else -}}
+{{- printf "%s-webhook-secret" (include "kup6s-pages.fullname" .) -}}
+{{- end -}}
+{{- end }}

--- a/charts/kup6s-pages/templates/_validation.tpl
+++ b/charts/kup6s-pages/templates/_validation.tpl
@@ -1,0 +1,10 @@
+{{/*
+Validate webhook configuration
+*/}}
+{{- define "kup6s-pages.validateWebhook" -}}
+{{- if .Values.webhook.enabled -}}
+{{- if not (include "kup6s-pages.webhook.hasSecret" .) -}}
+{{- fail "webhook.enabled=true requires a webhook secret. Set either webhook.secret or webhook.secretRef.name" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kup6s-pages/templates/deployment-syncer.yaml
+++ b/charts/kup6s-pages/templates/deployment-syncer.yaml
@@ -1,3 +1,4 @@
+{{- include "kup6s-pages.validateWebhook" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -39,9 +40,24 @@ spec:
             - --sites-root={{ .Values.syncer.sitesRoot }}
             - --sync-interval={{ .Values.syncer.syncInterval }}
             - --webhook-addr={{ .Values.syncer.webhookAddr }}
+            {{- if include "kup6s-pages.webhook.hasSecret" . }}
+            - --webhook-secret=$(WEBHOOK_SECRET)
+            {{- end }}
             {{- range .Values.syncer.extraArgs }}
             - {{ . }}
             {{- end }}
+          {{- if include "kup6s-pages.webhook.hasSecret" . }}
+          env:
+            - name: WEBHOOK_SECRET
+              {{- if .Values.webhook.secret }}
+              value: {{ .Values.webhook.secret | quote }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.webhook.secretRef.name }}
+                  key: {{ .Values.webhook.secretRef.key }}
+              {{- end }}
+          {{- end }}
           ports:
             - name: webhook
               containerPort: 8080

--- a/charts/kup6s-pages/values.yaml
+++ b/charts/kup6s-pages/values.yaml
@@ -320,6 +320,17 @@ webhook:
   # -- Additional IngressRoute annotations
   annotations: {}
 
+  # -- Webhook secret for HMAC signature validation
+  # REQUIRED when webhook.enabled=true. Either set secret directly or use secretRef.
+  secret: ""
+
+  # -- Reference to existing secret containing the webhook secret
+  secretRef:
+    # -- Name of the existing secret
+    name: ""
+    # -- Key in the secret containing the webhook secret value
+    key: "webhook-secret"
+
 # =============================================================================
 # RBAC Configuration
 # =============================================================================

--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -85,6 +85,11 @@ func main() {
 		WebhookSecret: webhookSecret,
 	}
 
+	// Warn if webhook secret is not configured
+	if webhookSecret == "" {
+		log.Info("WARNING: webhook secret not configured - webhook signature validation is disabled")
+	}
+
 	// Context with cancellation
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
## Summary
- Adds Helm chart validation that fails if `webhook.enabled=true` without configuring a secret
- Adds runtime warning in syncer if webhook secret is not configured
- Updates documentation to indicate webhook secret is required

## Changes
- `charts/kup6s-pages/values.yaml`: Added `webhook.secret` and `webhook.secretRef` options
- `charts/kup6s-pages/templates/_helpers.tpl`: Added helpers for webhook secret detection
- `charts/kup6s-pages/templates/_validation.tpl`: Created validation that fails early if webhook enabled without secret
- `charts/kup6s-pages/templates/deployment-syncer.yaml`: Pass webhook secret via environment variable
- `cmd/syncer/main.go`: Added startup warning if webhook secret is empty
- `README.md`: Updated documentation to indicate secret is required

## Test plan
- [ ] `helm lint charts/kup6s-pages` passes
- [ ] `helm unittest charts/kup6s-pages` passes
- [ ] `helm template` with `webhook.enabled=true` but no secret fails with clear error
- [ ] `helm template` with `webhook.enabled=true` and `webhook.secret=xxx` renders correctly
- [ ] `helm template` with `webhook.enabled=true` and `webhook.secretRef.name=xxx` renders correctly

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)