### PR TITLE
security: restrict syncer secret access to namespace-scoped RBAC

### DIFF
--- a/charts/kup6s-pages/examples/namespace-rbac.yaml
+++ b/charts/kup6s-pages/examples/namespace-rbac.yaml
@@ -1,0 +1,36 @@
+# Grant the kup6s-pages syncer access to read secrets in your namespace
+#
+# Apply this template in your namespace:
+#   kubectl apply -f namespace-rbac.yaml -n YOUR_NAMESPACE
+#
+# Replace the following placeholders:
+#   - YOUR_NAMESPACE: The namespace where your StaticSites and secrets are
+#   - kup6s-pages-syncer: The syncer ServiceAccount name (default: <release>-syncer)
+#   - kup6s-pages: The namespace where kup6s-pages is installed
+#
+# This is required for private Git repositories. Without this RBAC setup,
+# the syncer cannot read your Git credential secrets and syncing will fail.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pages-syncer-secrets
+  # Apply to your namespace: kubectl apply -f namespace-rbac.yaml -n YOUR_NAMESPACE
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pages-syncer-secrets
+  # Apply to your namespace: kubectl apply -f namespace-rbac.yaml -n YOUR_NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pages-syncer-secrets
+subjects:
+  - kind: ServiceAccount
+    name: kup6s-pages-syncer  # Adjust if using custom release name
+    namespace: kup6s-pages    # Namespace where kup6s-pages is installed

--- a/charts/kup6s-pages/templates/NOTES.txt
+++ b/charts/kup6s-pages/templates/NOTES.txt
@@ -22,6 +22,37 @@ Check StaticSite status:
   kubectl get staticsites -A
   kubectl describe staticsite my-website -n pages
 
+For PRIVATE repositories, grant the syncer access to secrets in your namespace:
+
+  cat <<EOF | kubectl apply -f -
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: pages-syncer-secrets
+    namespace: YOUR_NAMESPACE
+  rules:
+    - apiGroups: [""]
+      resources: ["secrets"]
+      verbs: ["get"]
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: pages-syncer-secrets
+    namespace: YOUR_NAMESPACE
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: pages-syncer-secrets
+  subjects:
+    - kind: ServiceAccount
+      name: {{ include "kup6s-pages.syncer.serviceAccountName" . }}
+      namespace: {{ include "kup6s-pages.namespace" . }}
+  EOF
+
+Then create a secret with your Git credentials and reference it in secretRef.
+See README.md "Private Repositories" section for details.
+
 {{- if .Values.webhook.enabled }}
 
 Webhook endpoint enabled at:

--- a/charts/kup6s-pages/templates/clusterrole-syncer.yaml
+++ b/charts/kup6s-pages/templates/clusterrole-syncer.yaml
@@ -13,9 +13,7 @@ rules:
   - apiGroups: ["pages.kup6s.com"]
     resources: ["staticsites/status"]
     verbs: ["get", "update", "patch"]
-
-  # Secrets for Git credentials
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get"]
+  # NOTE: Secrets access removed for security (issue #8)
+  # Users must create Role/RoleBinding in their namespace to grant syncer access
+  # See README.md "Private Repositories" section
 {{- end }}


### PR DESCRIPTION
## Summary

- Remove cluster-wide secret read permission from syncer ClusterRole
- Users must create Role/RoleBinding in their namespace to grant syncer access
- Document RBAC setup in README and NOTES.txt
- Add example namespace-rbac.yaml template

## Security Improvement

| Before | After |
|--------|-------|
| Syncer can read **all** secrets cluster-wide | Syncer can only read secrets in namespaces where users explicitly grant access |
| Single compromised pod = full cluster secret access | Compromised pod = only secrets in namespaces that granted access |

## Migration

Existing installations with private repos need to create Role/RoleBinding in namespaces with StaticSites before upgrading:

```bash
kubectl apply -f charts/kup6s-pages/examples/namespace-rbac.yaml -n YOUR_NAMESPACE
```

## Test plan

- [x] `helm lint charts/kup6s-pages` passes
- [x] `helm unittest charts/kup6s-pages` passes
- [x] Verify syncer ClusterRole no longer has secrets permission
- [ ] Deploy and verify private repo sync fails without user RBAC
- [ ] Apply user RBAC and verify sync succeeds

Closes #8