### PR TITLE
security: make SSRF allowlist mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ helm install pages oci://ghcr.io/kup6s/kup6s-pages --version 0.1.0
 helm install pages oci://ghcr.io/kup6s/kup6s-pages \
   --set operator.pagesDomain=pages.example.com \
   --set operator.clusterIssuer=letsencrypt-prod \
+  --set 'syncer.allowedHosts={github.com,gitlab.com}' \
   --set storage.storageClassName=longhorn \
   --set webhook.enabled=true \
   --set webhook.domain=webhook.pages.example.com
@@ -87,6 +88,7 @@ helm install pages oci://ghcr.io/kup6s/kup6s-pages \
 |-------|---------|-------------|
 | `operator.pagesDomain` | `pages.kup6s.com` | Base domain for auto-generated URLs |
 | `operator.clusterIssuer` | `letsencrypt-prod` | cert-manager ClusterIssuer |
+| `syncer.allowedHosts` | **Required** | Allowed Git hosts (SSRF protection) |
 | `storage.size` | `10Gi` | PVC size for sites |
 | `storage.storageClassName` | (default) | StorageClass (must support RWX) |
 | `nginx.replicas` | `2` | nginx replicas for HA |
@@ -368,7 +370,9 @@ The syncer accepts these flags:
 | `--sites-root` | `/sites` | Directory where sites are stored |
 | `--sync-interval` | `5m` | Default interval for polling repos |
 | `--webhook-addr` | `:8080` | Webhook HTTP server address |
-| `--allowed-hosts` | (none) | Comma-separated allowlist of Git hosts (SSRF protection) |
+| `--allowed-hosts` | **Required** | Comma-separated allowlist of Git hosts (SSRF protection) |
+
+Common allowed hosts examples: `github.com`, `gitlab.com`, `bitbucket.org`, `codeberg.org`. Wildcards are supported for self-hosted instances: `*.gitlab.example.com`.
 
 ## Troubleshooting
 
@@ -476,8 +480,8 @@ helm unittest charts/kup6s-pages
 # Operator (requires kubeconfig)
 go run ./cmd/operator --pages-domain=pages.local --cluster-issuer=selfsigned
 
-# Syncer
-go run ./cmd/syncer --sites-root=/tmp/sites --sync-interval=1m
+# Syncer (--allowed-hosts is required)
+go run ./cmd/syncer --sites-root=/tmp/sites --sync-interval=1m --allowed-hosts=github.com,gitlab.com
 ```
 
 ## License

--- a/charts/kup6s-pages/templates/deployment-syncer.yaml
+++ b/charts/kup6s-pages/templates/deployment-syncer.yaml
@@ -1,4 +1,7 @@
 {{- include "kup6s-pages.validateWebhook" . -}}
+{{- if not .Values.syncer.allowedHosts }}
+{{- fail "SECURITY: syncer.allowedHosts is required and cannot be empty. This setting limits which Git hosts can be cloned to prevent SSRF attacks. Example: [\"github.com\", \"gitlab.com\"]" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -40,6 +43,7 @@ spec:
             - --sites-root={{ .Values.syncer.sitesRoot }}
             - --sync-interval={{ .Values.syncer.syncInterval }}
             - --webhook-addr={{ .Values.syncer.webhookAddr }}
+            - --allowed-hosts={{ .Values.syncer.allowedHosts | join "," }}
             {{- if include "kup6s-pages.webhook.hasSecret" . }}
             - --webhook-secret=$(WEBHOOK_SECRET)
             {{- end }}

--- a/charts/kup6s-pages/tests/deployment-syncer_test.yaml
+++ b/charts/kup6s-pages/tests/deployment-syncer_test.yaml
@@ -1,6 +1,11 @@
 suite: syncer deployment tests
 templates:
   - templates/deployment-syncer.yaml
+set:
+  # allowedHosts is required for all tests
+  syncer.allowedHosts:
+    - github.com
+    - gitlab.com
 tests:
   - it: should render with default values
     asserts:
@@ -56,3 +61,19 @@ tests:
       - equal:
           path: metadata.labels["app.kubernetes.io/component"]
           value: syncer
+
+  - it: should set allowed-hosts argument
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --allowed-hosts=github.com,gitlab.com
+
+  - it: should set custom allowed-hosts
+    set:
+      syncer.allowedHosts:
+        - forgejo.example.com
+        - "*.gitlab.internal"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --allowed-hosts=forgejo.example.com,*.gitlab.internal

--- a/charts/kup6s-pages/values.yaml
+++ b/charts/kup6s-pages/values.yaml
@@ -139,6 +139,12 @@ syncer:
   # -- Sites root directory (inside the PVC)
   sitesRoot: "/sites"
 
+  # -- (REQUIRED) Allowed Git hosts for SSRF protection.
+  # The syncer will only clone repositories from these hosts.
+  # Supports wildcards: "*.gitlab.example.com"
+  # Example: ["github.com", "gitlab.com", "bitbucket.org"]
+  allowedHosts: []
+
   # -- Additional CLI arguments
   extraArgs: []
 

--- a/cmd/syncer/main.go
+++ b/cmd/syncer/main.go
@@ -59,7 +59,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Parse allowed hosts
+	// Parse allowed hosts (mandatory for SSRF protection)
 	var hosts []string
 	if allowedHosts != "" {
 		for _, h := range strings.Split(allowedHosts, ",") {
@@ -69,6 +69,15 @@ func main() {
 			}
 		}
 	}
+
+	if len(hosts) == 0 {
+		log.Error(nil, "SECURITY: --allowed-hosts is required and cannot be empty",
+			"hint", "This flag limits which Git hosts can be cloned to prevent SSRF attacks",
+			"example", "--allowed-hosts=github.com,gitlab.com")
+		os.Exit(1)
+	}
+
+	log.Info("Allowed Git hosts configured", "hosts", hosts)
 
 	// Create Syncer
 	s := &syncer.Syncer{

--- a/pkg/syncer/git.go
+++ b/pkg/syncer/git.go
@@ -33,16 +33,17 @@ type Syncer struct {
 	// Default sync interval
 	DefaultInterval time.Duration
 
-	// AllowedHosts is a list of allowed Git hosts (SSRF protection)
-	// If empty, all hosts are allowed
+	// AllowedHosts is a list of allowed Git hosts (SSRF protection).
+	// This field is mandatory - startup will fail if empty.
 	AllowedHosts []string
 }
 
 // validateRepoURL checks if the repo URL is allowed (SSRF protection)
 func (s *Syncer) validateRepoURL(repoURL string) error {
-	// If no allowlist configured, allow everything
+	// Defensive check - AllowedHosts should never be empty at runtime
+	// since main() validates this at startup
 	if len(s.AllowedHosts) == 0 {
-		return nil
+		return fmt.Errorf("internal error: AllowedHosts not configured")
 	}
 
 	parsed, err := url.Parse(repoURL)

--- a/pkg/syncer/git_test.go
+++ b/pkg/syncer/git_test.go
@@ -17,10 +17,10 @@ func TestValidateRepoURL(t *testing.T) {
 		wantErr      bool
 	}{
 		{
-			name:         "empty allowlist allows all",
+			name:         "empty allowlist returns error",
 			allowedHosts: nil,
 			repoURL:      "https://github.com/example/repo.git",
-			wantErr:      false,
+			wantErr:      true, // AllowedHosts is now mandatory
 		},
 		{
 			name:         "exact match allowed",


### PR DESCRIPTION
## Summary

- Makes `--allowed-hosts` mandatory for the syncer to prevent SSRF attacks
- Adds Helm chart validation requiring `syncer.allowedHosts` to be non-empty
- Logs configured hosts at startup for debugging
- Updates documentation with examples

## Test plan

- [x] Go tests pass (`go test ./...`)
- [x] Helm lint passes (`helm lint charts/kup6s-pages`)
- [x] Helm unit tests pass (`helm unittest charts/kup6s-pages`)
- [x] Verify helm template fails without allowedHosts
- [x] Verify helm template renders correctly with allowedHosts

Closes #9