### PR TITLE
fix(chart): add hardened security context to nginx container

### DIFF
--- a/charts/kup6s-pages/templates/deployment-nginx.yaml
+++ b/charts/kup6s-pages/templates/deployment-nginx.yaml
@@ -44,6 +44,10 @@ spec:
               readOnly: true
             - name: nginx-config
               mountPath: /etc/nginx/conf.d
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
           {{- with .Values.nginx.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -67,6 +71,10 @@ spec:
         - name: nginx-config
           configMap:
             name: {{ include "kup6s-pages.fullname" . }}-nginx
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
       {{- with .Values.nginx.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/kup6s-pages/values.yaml
+++ b/charts/kup6s-pages/values.yaml
@@ -223,7 +223,14 @@ nginx:
   podSecurityContext: {}
 
   # -- Container security context
-  securityContext: {}
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 101
+    capabilities:
+      drop:
+        - ALL
 
   # -- Resource requests and limits
   resources:


### PR DESCRIPTION
## Summary

- Add hardened security context to nginx container with `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `runAsNonRoot: true`, `runAsUser: 101`, and drop ALL capabilities
- Add emptyDir volumes for `/var/cache/nginx` and `/var/run` to support read-only root filesystem

## Test plan

- [ ] Verify helm unittests pass
- [ ] Verify nginx starts with hardened security context
- [ ] Verify nginx can serve static files with hardened context

Closes #10