### PR TITLE
fix(chart): complete syncer container security context

### DIFF
--- a/charts/kup6s-pages/values.yaml
+++ b/charts/kup6s-pages/values.yaml
@@ -158,9 +158,14 @@ syncer:
   podSecurityContext: {}
 
   # -- Container security context
+  # Note: readOnlyRootFilesystem not used - syncer needs writable /tmp for git operations
   securityContext:
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
     runAsUser: 1000
+    capabilities:
+      drop:
+        - ALL
 
   # -- Resource requests and limits
   resources:


### PR DESCRIPTION
## Summary

- Add missing security context fields to syncer container: `allowPrivilegeEscalation: false` and `capabilities.drop: [ALL]`
- Document why `readOnlyRootFilesystem` is not used (syncer needs writable `/tmp` for git operations)

## Test plan

- [ ] Verify helm unittests pass
- [ ] Verify syncer can clone and sync git repositories with hardened context

Closes #11