### PR TITLE
security(chart): scope down operator RBAC permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,20 @@ TOKEN=$(kubectl get staticsite my-website -n pages -o jsonpath='{.status.syncTok
 curl -H "X-API-Key: $TOKEN" -X POST https://webhook.pages.kup6s.com/sync/pages/my-website
 ```
 
+## Security
+
+The operator uses a ClusterRole because it watches StaticSite resources across all namespaces.
+All managed resources (IngressRoutes, Middlewares, Certificates, Services) are created in the
+StaticSite's namespace, following the principle of least privilege.
+
+Key security features:
+- Operator cannot create or delete StaticSite resources (users do that)
+- Syncer has no secrets access by default (opt-in via namespace Roles)
+- SSRF protection via mandatory `--allowed-hosts` flag
+- All pods run as non-root with read-only root filesystem
+
+See [docs/SECURITY.md](docs/SECURITY.md) for detailed RBAC documentation.
+
 ## Development
 
 ### Project Structure

--- a/charts/kup6s-pages/templates/clusterrole-operator.yaml
+++ b/charts/kup6s-pages/templates/clusterrole-operator.yaml
@@ -5,11 +5,19 @@ metadata:
   name: {{ include "kup6s-pages.fullname" . }}-operator
   labels:
     {{- include "kup6s-pages.operator.labels" . | nindent 4 }}
+# ClusterRole Rationale:
+# The operator watches StaticSites across all namespaces (multi-tenant design).
+# Resources (IngressRoutes, Middlewares, Certificates, Services) are created
+# in the StaticSite's namespace, not a fixed system namespace.
+# This is the standard pattern for namespace-scoped operators.
+# See docs/SECURITY.md for detailed RBAC documentation.
 rules:
-  # StaticSite CRD
+  # StaticSite CRD - watch and manage existing resources
+  # The operator does NOT create or delete StaticSites (users do that).
+  # update/patch needed for adding finalizers.
   - apiGroups: ["pages.kup6s.com"]
     resources: ["staticsites"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+    verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["pages.kup6s.com"]
     resources: ["staticsites/status"]
     verbs: ["get", "update", "patch"]
@@ -18,26 +26,32 @@ rules:
     verbs: ["update"]
 
   # Traefik IngressRoutes and Middlewares
+  # Created in StaticSite's namespace with ownerReferences for automatic cleanup.
+  # delete needed for garbage collection via ownerReferences.
   - apiGroups: ["traefik.io"]
     resources: ["ingressroutes", "middlewares"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
   # cert-manager Certificates
+  # Created in StaticSite's namespace. Shared across sites with same domain.
+  # delete needed for explicit cleanup when no sites use the domain.
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
-  # Core Services (for nginx proxy ExternalName services)
+  # Core Services (ExternalName services for cross-namespace nginx routing)
+  # Created in StaticSite's namespace. Shared across all sites in that namespace.
+  # delete needed for explicit cleanup when last site in namespace is deleted.
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 
-  # Events
+  # Events - for recording reconciliation events
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
 
-  # Coordination for Leader Election
+  # Coordination Leases - for leader election
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/charts/kup6s-pages/tests/rbac_test.yaml
+++ b/charts/kup6s-pages/tests/rbac_test.yaml
@@ -35,7 +35,7 @@ tests:
           content:
             apiGroups: ["pages.kup6s.com"]
             resources: ["staticsites"]
-            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+            verbs: ["get", "list", "watch", "update", "patch"]
 
   - it: should create syncer clusterrole with correct API group
     template: templates/clusterrole-syncer.yaml

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,148 @@
+# Security Documentation
+
+This document describes the RBAC configuration and security considerations for kup6s-pages.
+
+## RBAC Architecture
+
+The operator uses a **ClusterRole** because it watches StaticSite resources across all
+namespaces (multi-tenant design). This is the standard pattern for namespace-scoped
+operators like cert-manager and ArgoCD.
+
+### Resource Creation Pattern
+
+All managed resources are created in the **StaticSite's namespace**, not a fixed system
+namespace:
+
+| Resource | Location | Ownership |
+|----------|----------|-----------|
+| IngressRoutes | StaticSite's namespace | ownerReferences (auto-cleanup) |
+| Middlewares | StaticSite's namespace | ownerReferences (auto-cleanup) |
+| Certificates | StaticSite's namespace | Labels (shared across sites) |
+| Services | StaticSite's namespace | Labels (shared across sites) |
+
+## Operator Permissions
+
+### StaticSite CRD
+
+```yaml
+verbs: ["get", "list", "watch", "update", "patch"]
+```
+
+- **get/list/watch**: Core reconciliation loop
+- **update/patch**: Adding finalizers for cleanup coordination
+- **create/delete**: Not granted (users create/delete StaticSites)
+
+### Traefik Resources (IngressRoutes, Middlewares)
+
+```yaml
+verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+```
+
+- **create**: Creates IngressRoutes and Middlewares for each StaticSite
+- **delete**: Required for garbage collection via ownerReferences
+
+### cert-manager Certificates
+
+```yaml
+verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+```
+
+- **create**: Issues TLS certificates for custom domains
+- **delete**: Explicit cleanup when no sites use a domain (certificates are shared)
+
+### Core Services
+
+```yaml
+verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+```
+
+- **create**: Creates ExternalName services for cross-namespace nginx routing
+- **delete**: Explicit cleanup when last StaticSite in namespace is deleted
+
+### Events
+
+```yaml
+verbs: ["create", "patch"]
+```
+
+Records reconciliation events on StaticSite resources.
+
+### Coordination Leases
+
+```yaml
+verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+```
+
+Required for leader election in multi-replica deployments.
+
+## Syncer Permissions
+
+The syncer has minimal permissions - read-only access to StaticSites plus status updates:
+
+```yaml
+# StaticSites: read-only + status
+verbs: ["get", "list", "watch"]  # for staticsites
+verbs: ["get", "update", "patch"]  # for staticsites/status
+```
+
+Secrets access is **not granted by default**. Users must create namespace-scoped Roles
+to grant the syncer access to Git credentials. See the README for configuration details.
+
+## Security Considerations
+
+### Principle of Least Privilege
+
+- The operator cannot create or delete StaticSite resources
+- The syncer has no secrets access by default
+- All resources are scoped to user namespaces
+
+### Shared Resource Management
+
+Some resources are shared across multiple StaticSites:
+
+- **Certificates**: Shared by sites with the same domain
+- **Services**: Shared by all sites in a namespace
+
+The operator uses labels to track ownership and performs explicit orphan checks before
+deletion to prevent accidental removal of resources still in use.
+
+### Cross-Namespace Access
+
+The syncer can be granted secrets access in user namespaces via RoleBindings:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pages-syncer-secrets
+  namespace: customer-namespace
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pages-syncer-secrets
+  namespace: customer-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pages-syncer-secrets
+subjects:
+  - kind: ServiceAccount
+    name: kup6s-pages-syncer
+    namespace: kup6s-pages
+```
+
+This grants read-only access to secrets in the customer namespace only.
+
+## Additional Hardening
+
+For environments requiring additional restrictions:
+
+1. **OPA/Gatekeeper policies**: Restrict which namespaces can contain StaticSites
+2. **Network policies**: Limit operator/syncer egress to required endpoints
+3. **Pod security standards**: Both operator and syncer run as non-root with read-only
+   root filesystem


### PR DESCRIPTION
## Summary

- Remove `create`/`delete` verbs from StaticSite permissions (operator only watches and manages existing resources)
- Add detailed comments explaining each permission and why it's needed
- Add `docs/SECURITY.md` with comprehensive RBAC documentation
- Add Security section to README.md

## Analysis

After investigating issue #14, the ClusterRole is appropriate because:
- The operator watches StaticSites across all namespaces (multi-tenant design)
- Resources are created in the StaticSite's namespace, not a fixed system namespace
- This is the standard pattern for namespace-scoped operators (cert-manager, ArgoCD)

However, the operator does NOT need `create` or `delete` permissions on StaticSites themselves (users do that).

## Test plan

- [x] `make lint` passes
- [x] `helm unittest charts/kup6s-pages` passes (43 tests)
- [ ] Deploy to test cluster and verify operator still reconciles StaticSites

Closes #14