### PR TITLE
feat(controller): add Certificate status conditions to StaticSite

### DIFF
--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -144,6 +144,12 @@ const (
 	PhaseError   Phase = "Error"
 )
 
+// Condition types for StaticSite
+const (
+	// ConditionCertificateReady indicates whether the TLS certificate is ready
+	ConditionCertificateReady = "CertificateReady"
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:object:root=true
 


### PR DESCRIPTION
## Summary

- Add `CertificateReady` condition to StaticSite status, surfacing cert-manager Certificate status
- Watch Certificate resources in the system namespace and map changes back to StaticSites via `pages.kup6s.com/domain` label
- Handles shared certificates (multiple sites using same domain get updated when certificate status changes)

## Implementation

1. Added `ConditionCertificateReady` constant in [types.go](pkg/apis/v1alpha1/types.go)
2. Added Certificate watch in `SetupWithManager` using `WatchesRawSource` with a mapping function
3. `mapCertificateToStaticSites()` finds all StaticSites sharing the same domain
4. `updateCertificateCondition()` reads Certificate status and propagates Ready condition to StaticSite

Users can now see certificate status via:
```bash
kubectl get staticsite my-site -o jsonpath='{.status.conditions}'
```

## Test plan

- [x] `make lint` passes
- [x] `go test ./...` passes  
- [x] `helm unittest charts/kup6s-pages` passes
- [ ] Manual test: create StaticSite with custom domain, verify CertificateReady condition updates

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)