### PR TITLE
fix: log cleanup errors instead of silently discarding

### DIFF
--- a/pkg/syncer/git.go
+++ b/pkg/syncer/git.go
@@ -210,7 +210,10 @@ func (s *Syncer) syncSite(ctx context.Context, site *staticSiteData) error {
 			return fmt.Errorf("git clone failed: %w", err)
 		}
 
-		head, _ := repo.Head()
+		head, err := repo.Head()
+		if err != nil {
+			logger.V(1).Info("Failed to get HEAD after clone", "error", err)
+		}
 		if head != nil {
 			commitHash = head.Hash().String()[:8]
 		}
@@ -243,7 +246,10 @@ func (s *Syncer) syncSite(ctx context.Context, site *staticSiteData) error {
 			return fmt.Errorf("git pull failed: %w", err)
 		}
 
-		head, _ := repo.Head()
+		head, err := repo.Head()
+		if err != nil {
+			logger.V(1).Info("Failed to get HEAD after pull", "error", err)
+		}
 		if head != nil {
 			commitHash = head.Hash().String()[:8]
 		}
@@ -460,7 +466,9 @@ func (s *Syncer) Cleanup(ctx context.Context) error {
 			if !activeSites[name] {
 				repoPath := filepath.Join(reposDir, name)
 				logger.Info("Removing orphaned repo directory", "name", name)
-				_ = os.RemoveAll(repoPath)
+				if err := os.RemoveAll(repoPath); err != nil {
+					logger.Error(err, "Failed to remove orphaned repo", "path", repoPath)
+				}
 			}
 		}
 	}

--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -305,7 +305,9 @@ func (w *WebhookServer) Start(ctx context.Context, addr string) error {
 
 	go func() {
 		<-ctx.Done()
-		_ = server.Shutdown(context.Background())
+		if err := server.Shutdown(context.Background()); err != nil {
+			logger.Error(err, "Server shutdown error")
+		}
 	}()
 
 	logger.Info("Starting webhook server", "addr", addr)


### PR DESCRIPTION
## Summary
- Add debug logging for `repo.Head()` errors after clone/pull
- Log `os.RemoveAll` errors when cleaning up orphaned repos  
- Log server shutdown errors

Fixes #52