### PR TITLE
fix(syncer): add shutdown timeout context for webhook server

### DIFF
--- a/pkg/syncer/server_test.go
+++ b/pkg/syncer/server_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestValidateWebhookSignature(t *testing.T) {
@@ -275,5 +276,19 @@ func TestDeleteEndpointOldFormatReturns404(t *testing.T) {
 
 	if rr.Code != http.StatusNotFound {
 		t.Errorf("old format: status = %d, want %d (NotFound)", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestShutdownTimeoutDefault(t *testing.T) {
+	w := &WebhookServer{}
+
+	if w.ShutdownTimeout != 0 {
+		t.Errorf("default ShutdownTimeout = %v, want 0 (uses DefaultShutdownTimeout)", w.ShutdownTimeout)
+	}
+}
+
+func TestDefaultShutdownTimeoutValue(t *testing.T) {
+	if DefaultShutdownTimeout != 30*time.Second {
+		t.Errorf("DefaultShutdownTimeout = %v, want 30s", DefaultShutdownTimeout)
 	}
 }


### PR DESCRIPTION
## Summary

- Add 30-second timeout for graceful server shutdown to prevent indefinite hangs
- Log shutdown errors instead of silently ignoring them
- Make timeout configurable via `ShutdownTimeout` field

## Test plan

- [x] Unit tests verify default timeout value (30s)
- [x] All existing tests pass
- [x] Lint passes

Closes #55