### PR TITLE
fix: use appropriate requeue delay instead of 1ms

### DIFF
--- a/pkg/controller/staticsite.go
+++ b/pkg/controller/staticsite.go
@@ -33,8 +33,9 @@ import (
 var randReader io.Reader = rand.Reader
 
 const (
-	finalizerName         = "pages.kup6s.com/finalizer"
-	maxK8sResourceNameLen = 63
+	finalizerName           = "pages.kup6s.com/finalizer"
+	maxK8sResourceNameLen   = 63
+	immediateRequeueDelay   = 100 * time.Millisecond
 )
 
 // truncateK8sName truncates a name to the Kubernetes resource name length limit
@@ -163,7 +164,7 @@ func (r *StaticSiteReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err := r.Update(ctx, site); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{RequeueAfter: time.Millisecond}, nil
+		return ctrl.Result{RequeueAfter: immediateRequeueDelay}, nil
 	}
 
 	// 4. Generate sync token if not present
@@ -177,7 +178,7 @@ func (r *StaticSiteReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, err
 		}
 		logger.Info("Generated sync token", "name", site.Name)
-		return ctrl.Result{RequeueAfter: time.Millisecond}, nil
+		return ctrl.Result{RequeueAfter: immediateRequeueDelay}, nil
 	}
 
 	// 5. Validate pathPrefix


### PR DESCRIPTION
## Summary
- Replace aggressive 1ms requeue timing with a reasonable 100ms delay constant
- Reduces unnecessary API server churn while still providing quick reconciliation

## Test plan
- [x] Unit tests pass
- [x] Linter passes
- [ ] Verify finalizer and token generation still work correctly in cluster

Fixes #54