### PR TITLE
fix(syncer): use comma-ok idiom for type assertion in fromUnstructured

### DIFF
--- a/pkg/syncer/git.go
+++ b/pkg/syncer/git.go
@@ -390,9 +390,11 @@ func (s *staticSiteData) fromUnstructured(u *unstructured.Unstructured) error {
 	}
 
 	if secretRefMap, ok := spec["secretRef"].(map[string]interface{}); ok {
-		s.SecretRef = &secretRef{
-			Name: secretRefMap["name"].(string),
+		name, nameOK := secretRefMap["name"].(string)
+		if !nameOK {
+			return fmt.Errorf("secretRef.name is required and must be a string")
 		}
+		s.SecretRef = &secretRef{Name: name}
 		if key, ok := secretRefMap["key"].(string); ok {
 			s.SecretRef.Key = key
 		}

--- a/pkg/syncer/git_test.go
+++ b/pkg/syncer/git_test.go
@@ -169,6 +169,56 @@ func TestStaticSiteDataFromUnstructured(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "secretRef missing name field",
+			obj: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":      "test-site",
+					"namespace": "pages",
+				},
+				"spec": map[string]interface{}{
+					"repo": "https://github.com/example/repo.git",
+					"secretRef": map[string]interface{}{
+						"key": "token",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "secretRef name is wrong type",
+			obj: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":      "test-site",
+					"namespace": "pages",
+				},
+				"spec": map[string]interface{}{
+					"repo": "https://github.com/example/repo.git",
+					"secretRef": map[string]interface{}{
+						"name": 123,
+						"key":  "token",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "secretRef name is nil",
+			obj: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":      "test-site",
+					"namespace": "pages",
+				},
+				"spec": map[string]interface{}{
+					"repo": "https://github.com/example/repo.git",
+					"secretRef": map[string]interface{}{
+						"name": nil,
+						"key":  "token",
+					},
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -179,6 +229,9 @@ func TestStaticSiteDataFromUnstructured(t *testing.T) {
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("fromUnstructured() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
 				return
 			}
 


### PR DESCRIPTION
## Summary

- Replace unsafe type assertion `secretRefMap["name"].(string)` with comma-ok idiom
- Return descriptive error when secretRef.name is missing or wrong type
- Add test cases for malformed secretRef (missing name, wrong type, nil value)

Closes #57