### PR TITLE
fix: use appropriate requeue delay instead of 1ms

### DIFF
--- a/pkg/controller/staticsite.go
+++ b/pkg/controller/staticsite.go
@@ -44,6 +44,9 @@ const (
 
 	// errorRetryInterval is how long to wait before retrying after an error
 	errorRetryInterval = 30 * time.Second
+
+	// immediateRequeueDelay is a short delay for requeuing after state changes
+	immediateRequeueDelay = 100 * time.Millisecond
 )
 
 // truncateK8sName truncates a name to the Kubernetes resource name length limit
@@ -172,7 +175,7 @@ func (r *StaticSiteReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err := r.Update(ctx, site); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{RequeueAfter: time.Millisecond}, nil
+		return ctrl.Result{RequeueAfter: immediateRequeueDelay}, nil
 	}
 
 	// 4. Generate sync token if not present
@@ -186,7 +189,7 @@ func (r *StaticSiteReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, err
 		}
 		logger.Info("Generated sync token", "name", site.Name)
-		return ctrl.Result{RequeueAfter: time.Millisecond}, nil
+		return ctrl.Result{RequeueAfter: immediateRequeueDelay}, nil
 	}
 
 	// 5. Validate pathPrefix


### PR DESCRIPTION
## Summary
- Add `immediateRequeueDelay` constant (100ms) alongside existing timing constants
- Replace aggressive 1ms requeue with the new constant for finalizer/token operations

## Test plan
- [x] Unit tests pass
- [x] Linter passes

Fixes #54