### PR TITLE
refactor(syncer): remove unused logger in ServeHTTP

### DIFF
--- a/pkg/syncer/server.go
+++ b/pkg/syncer/server.go
@@ -37,7 +37,6 @@ type WebhookServer struct {
 // ServeHTTP implements http.Handler
 func (w *WebhookServer) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	_ = log.FromContext(ctx) // Logger for later use
 
 	// Routing
 	path := strings.TrimPrefix(r.URL.Path, "/")


### PR DESCRIPTION
## Summary
- Removes unused logger variable in `ServeHTTP()` router function
- Each handler function already obtains its own logger from context when needed

Closes #59