### PR TITLE
fix(syncer): use TrimPrefix for safe subpath normalization

### DIFF
--- a/pkg/syncer/git.go
+++ b/pkg/syncer/git.go
@@ -277,9 +277,7 @@ func (s *Syncer) syncSite(ctx context.Context, site *staticSiteData) error {
 func (s *Syncer) setupSubpath(siteName, repoDir, subpath string) error {
 	// Normalize subpath (remove leading /)
 	subpath = filepath.Clean(subpath)
-	if subpath[0] == '/' {
-		subpath = subpath[1:]
-	}
+	subpath = strings.TrimPrefix(subpath, "/")
 
 	// Source directory: the cloned repo + subpath
 	srcDir := filepath.Join(repoDir, subpath)

--- a/pkg/syncer/git_test.go
+++ b/pkg/syncer/git_test.go
@@ -336,6 +336,30 @@ func TestSetupSubpath(t *testing.T) {
 			wantErr:   false,
 			checkLink: true,
 		},
+		{
+			name:     "handles root path (just slash)",
+			siteName: "rootsite",
+			subpath:  "/",
+			setup: func() string {
+				repoDir := filepath.Join(tmpDir, ".repos", "rootsite")
+				_ = os.MkdirAll(repoDir, 0755)
+				return repoDir
+			},
+			wantErr:   false,
+			checkLink: true,
+		},
+		{
+			name:     "handles empty subpath as root",
+			siteName: "emptysite",
+			subpath:  "",
+			setup: func() string {
+				repoDir := filepath.Join(tmpDir, ".repos", "emptysite")
+				_ = os.MkdirAll(repoDir, 0755)
+				return repoDir
+			},
+			wantErr:   false,
+			checkLink: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Replace direct array access `subpath[0]` with `strings.TrimPrefix` for defensive coding
- Add test cases for edge cases: empty string and root path (`/`)

Fixes #58

## Test plan
- [x] Existing tests pass
- [x] New edge case tests pass
- [x] Lint passes