### PR TITLE
refactor: translate German comments to English

### DIFF
--- a/pkg/controller/staticsite_test.go
+++ b/pkg/controller/staticsite_test.go
@@ -238,22 +238,22 @@ func TestReconcile_Deletion(t *testing.T) {
 		t.Fatalf("Reconcile() error = %v", err)
 	}
 
-	// Nach Finalizer-Entfernung: keine Requeue nötig
+	// After finalizer removal: no requeue needed
 	if result.RequeueAfter != 0 {
 		t.Error("expected RequeueAfter=0 after deletion handling")
 	}
 
-	// Das Objekt wird nach Finalizer-Entfernung vom API-Server gelöscht
-	// Der Fake-Client simuliert das - daher ist NotFound erwartet
+	// The object is deleted by the API server after finalizer removal
+	// The fake client simulates this - so NotFound is expected
 	updatedSite := &pagesv1.StaticSite{}
 	err = fakeClient.Get(context.Background(), req.NamespacedName, updatedSite)
 	if err == nil {
-		// Wenn es noch existiert, sollte der Finalizer entfernt sein
+		// If it still exists, the finalizer should be removed
 		if len(updatedSite.Finalizers) > 0 {
 			t.Errorf("Finalizers = %v, want empty", updatedSite.Finalizers)
 		}
 	}
-	// NotFound ist auch OK - bedeutet Objekt wurde gelöscht
+	// NotFound is also OK - means object was deleted
 }
 
 func TestDomainGeneration(t *testing.T) {

--- a/pkg/syncer/fake_client_test.go
+++ b/pkg/syncer/fake_client_test.go
@@ -47,7 +47,7 @@ func (f *fakeNamespaceableResource) List(ctx context.Context, opts metav1.ListOp
 	return &unstructured.UnstructuredList{Items: items}, nil
 }
 
-// Nicht benötigte Methoden - minimal implementiert
+// Unused methods - minimally implemented
 func (f *fakeNamespaceableResource) Create(ctx context.Context, obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
 	return obj, nil
 }

--- a/pkg/syncer/git_test.go
+++ b/pkg/syncer/git_test.go
@@ -267,7 +267,7 @@ func TestStaticSiteDataFromUnstructured(t *testing.T) {
 }
 
 func TestSetupSubpath(t *testing.T) {
-	// Temp-Verzeichnis erstellen
+	// Create temp directory
 	tmpDir, err := os.MkdirTemp("", "syncer-test-*")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
@@ -328,7 +328,7 @@ func TestSetupSubpath(t *testing.T) {
 				repoDir := filepath.Join(tmpDir, ".repos", "replace")
 				_ = os.MkdirAll(filepath.Join(repoDir, "old"), 0755)
 				_ = os.MkdirAll(filepath.Join(repoDir, "new"), 0755)
-				// Alten Symlink erstellen
+				// Create old symlink
 				linkPath := filepath.Join(tmpDir, "replace")
 				_ = os.Symlink(filepath.Join(repoDir, "old"), linkPath)
 				return repoDir
@@ -662,20 +662,20 @@ func TestCleanup(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	// Setup: Einige Site-Verzeichnisse erstellen
+	// Setup: Create some site directories
 	_ = os.MkdirAll(filepath.Join(tmpDir, "active-site"), 0755)
 	_ = os.MkdirAll(filepath.Join(tmpDir, "orphan-site"), 0755)
 	_ = os.MkdirAll(filepath.Join(tmpDir, ".repos", "active-site"), 0755)
 	_ = os.MkdirAll(filepath.Join(tmpDir, ".repos", "orphan-repo"), 0755)
 
-	// Symlink für orphan
+	// Symlink for orphan
 	_ = os.MkdirAll(filepath.Join(tmpDir, ".repos", "orphan-link", "dist"), 0755)
 	_ = os.Symlink(
 		filepath.Join(tmpDir, ".repos", "orphan-link", "dist"),
 		filepath.Join(tmpDir, "orphan-link"),
 	)
 
-	// Mock DynamicClient der nur "active-site" zurückgibt
+	// Mock DynamicClient that only returns "active-site"
 	s := &Syncer{
 		SitesRoot:     tmpDir,
 		DynamicClient: &fakeDynamicClient{activeSites: []string{"active-site"}},
@@ -687,27 +687,27 @@ func TestCleanup(t *testing.T) {
 		t.Fatalf("Cleanup() error = %v", err)
 	}
 
-	// active-site sollte noch existieren
+	// active-site should still exist
 	if _, err := os.Stat(filepath.Join(tmpDir, "active-site")); os.IsNotExist(err) {
 		t.Error("active-site was deleted but should exist")
 	}
 
-	// orphan-site sollte gelöscht sein
+	// orphan-site should be deleted
 	if _, err := os.Stat(filepath.Join(tmpDir, "orphan-site")); !os.IsNotExist(err) {
 		t.Error("orphan-site still exists but should be deleted")
 	}
 
-	// orphan-link (symlink) sollte gelöscht sein
+	// orphan-link (symlink) should be deleted
 	if _, err := os.Lstat(filepath.Join(tmpDir, "orphan-link")); !os.IsNotExist(err) {
 		t.Error("orphan-link still exists but should be deleted")
 	}
 
-	// .repos/orphan-repo sollte gelöscht sein
+	// .repos/orphan-repo should be deleted
 	if _, err := os.Stat(filepath.Join(tmpDir, ".repos", "orphan-repo")); !os.IsNotExist(err) {
 		t.Error(".repos/orphan-repo still exists but should be deleted")
 	}
 
-	// .repos/active-site sollte noch existieren
+	// .repos/active-site should still exist
 	if _, err := os.Stat(filepath.Join(tmpDir, ".repos", "active-site")); os.IsNotExist(err) {
 		t.Error(".repos/active-site was deleted but should exist")
 	}


### PR DESCRIPTION
## Summary

- Translate all German comments in test files to English for consistency
- Covers comments in `pkg/controller/staticsite_test.go`, `pkg/syncer/git_test.go`, and `pkg/syncer/fake_client_test.go`
- No functional changes, only comment translations

Closes #63
Part of #46

## Test plan

- [x] `make lint` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes