### PR TITLE
Add Helm unit tests for PDB and namespace RBAC

### DIFF
--- a/charts/kup6s-pages/tests/pdb_test.yaml
+++ b/charts/kup6s-pages/tests/pdb_test.yaml
@@ -1,0 +1,48 @@
+suite: PodDisruptionBudget tests
+templates:
+  - templates/pdb-nginx.yaml
+tests:
+  - it: should create PDB with default values
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: apiVersion
+          value: policy/v1
+      - matchRegex:
+          path: metadata.name
+          pattern: -nginx$
+      - equal:
+          path: spec.minAvailable
+          value: 1
+
+  - it: should use custom minAvailable value
+    set:
+      nginx.pdb.minAvailable: 2
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 2
+
+  - it: should not create PDB when disabled
+    set:
+      nginx.pdb.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have correct selector labels
+    asserts:
+      - exists:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: nginx
+
+  - it: should be in correct namespace
+    set:
+      namespace: custom-namespace
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace

--- a/charts/kup6s-pages/tests/rbac_test.yaml
+++ b/charts/kup6s-pages/tests/rbac_test.yaml
@@ -6,6 +6,8 @@ templates:
   - templates/clusterrole-syncer.yaml
   - templates/clusterrolebinding-operator.yaml
   - templates/clusterrolebinding-syncer.yaml
+  - templates/role-operator.yaml
+  - templates/rolebinding-operator.yaml
 tests:
   - it: should create operator serviceaccount
     template: templates/serviceaccount-operator.yaml
@@ -61,6 +63,92 @@ tests:
     template: templates/serviceaccount-operator.yaml
     set:
       operator.serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # Namespace-scoped Role tests
+  - it: should create operator role for namespace-scoped resources
+    template: templates/role-operator.yaml
+    asserts:
+      - isKind:
+          of: Role
+      - matchRegex:
+          path: metadata.name
+          pattern: -operator$
+
+  - it: should grant traefik ingressroute permissions in role
+    template: templates/role-operator.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["traefik.io"]
+            resources: ["ingressroutes", "middlewares"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - it: should grant cert-manager certificate permissions in role
+    template: templates/role-operator.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["cert-manager.io"]
+            resources: ["certificates"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - it: should grant coordination lease permissions in role
+    template: templates/role-operator.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["coordination.k8s.io"]
+            resources: ["leases"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - it: should not create role when rbac disabled
+    template: templates/role-operator.yaml
+    set:
+      rbac.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # Namespace-scoped RoleBinding tests
+  - it: should create operator rolebinding
+    template: templates/rolebinding-operator.yaml
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - matchRegex:
+          path: metadata.name
+          pattern: -operator$
+
+  - it: should reference correct role in rolebinding
+    template: templates/rolebinding-operator.yaml
+    asserts:
+      - equal:
+          path: roleRef.kind
+          value: Role
+      - matchRegex:
+          path: roleRef.name
+          pattern: -operator$
+
+  - it: should reference correct serviceaccount in rolebinding
+    template: templates/rolebinding-operator.yaml
+    asserts:
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - matchRegex:
+          path: subjects[0].name
+          pattern: -operator$
+
+  - it: should not create rolebinding when rbac disabled
+    template: templates/rolebinding-operator.yaml
+    set:
+      rbac.create: false
     asserts:
       - hasDocuments:
           count: 0


### PR DESCRIPTION
## Summary
- Create `pdb_test.yaml` with tests for minAvailable, disabled state, and selector labels
- Extend `rbac_test.yaml` with Role and RoleBinding tests
- Verify namespace-scoped permissions for traefik.io, cert-manager.io, coordination.k8s.io

Closes #88
Part of #82

## Test plan
- [x] All Helm unit tests pass (88 tests)
- [x] Lint passes