### PR TITLE
fix: add missing status.resources and observedGeneration to CRD schema

### DIFF
--- a/charts/kup6s-pages/crds/staticsites.pages.kup6s.com.yaml
+++ b/charts/kup6s-pages/crds/staticsites.pages.kup6s.com.yaml
@@ -105,9 +105,29 @@ spec:
                         type: string
                       message:
                         type: string
+                      observedGeneration:
+                        type: integer
+                        format: int64
+                        description: Generation of the resource when this condition was observed
                 syncToken:
                   type: string
                   description: Token for authenticating /sync and /site API calls
+                resources:
+                  type: object
+                  description: References to managed Kubernetes resources
+                  properties:
+                    ingressRoute:
+                      type: string
+                      description: namespace/name of the Traefik IngressRoute
+                    middleware:
+                      type: string
+                      description: namespace/name of the addPrefix Middleware
+                    stripMiddleware:
+                      type: string
+                      description: namespace/name of the stripPrefix Middleware (when pathPrefix is set)
+                    certificate:
+                      type: string
+                      description: namespace/name of the Certificate (when custom domain is set)
       subresources:
         status: {}
       additionalPrinterColumns:


### PR DESCRIPTION
## Summary

- Adds `status.resources` schema with properties for `ingressRoute`, `middleware`, `stripMiddleware`, and `certificate`
- Adds `observedGeneration` to `status.conditions[]` items per Kubernetes API conventions

These fields were already being written by the operator but were missing from the CRD schema, causing validation warnings.

Fixes #102

## Test plan

- [ ] Verify CRD applies cleanly: `kubectl apply -f charts/kup6s-pages/crds/staticsites.pages.kup6s.com.yaml`
- [ ] Verify no more "unknown field" warnings when reconciling StaticSite resources
- [ ] Verify `kubectl get staticsite -o yaml` shows resources and observedGeneration fields