### PR TITLE
feat: make TLS for auto-generated domains configurable

### DIFF
--- a/charts/kup6s-pages/templates/deployment-operator.yaml
+++ b/charts/kup6s-pages/templates/deployment-operator.yaml
@@ -42,6 +42,8 @@ spec:
             - --nginx-service-name={{ include "kup6s-pages.fullname" . }}-nginx
             - --metrics-bind-address={{ .Values.operator.metricsBindAddress }}
             - --health-probe-bind-address={{ .Values.operator.healthProbeBindAddress }}
+            - --pages-tls-mode={{ .Values.operator.pagesTlsMode }}
+            - --pages-wildcard-secret={{ .Values.operator.pagesWildcardSecret }}
             {{- range .Values.operator.extraArgs }}
             - {{ . }}
             {{- end }}

--- a/charts/kup6s-pages/tests/deployment-operator_test.yaml
+++ b/charts/kup6s-pages/tests/deployment-operator_test.yaml
@@ -71,3 +71,31 @@ tests:
       - equal:
           path: metadata.labels["app.kubernetes.io/component"]
           value: operator
+
+  - it: should set default pages-tls-mode to individual
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --pages-tls-mode=individual
+
+  - it: should set default pages-wildcard-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --pages-wildcard-secret=pages-wildcard-tls
+
+  - it: should set custom pages-tls-mode
+    set:
+      operator.pagesTlsMode: wildcard
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --pages-tls-mode=wildcard
+
+  - it: should set custom pages-wildcard-secret
+    set:
+      operator.pagesWildcardSecret: my-custom-wildcard-cert
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --pages-wildcard-secret=my-custom-wildcard-cert

--- a/charts/kup6s-pages/values.yaml
+++ b/charts/kup6s-pages/values.yaml
@@ -44,6 +44,15 @@ operator:
   # -- cert-manager ClusterIssuer name for TLS certificates
   clusterIssuer: "letsencrypt-prod"
 
+  # -- TLS mode for auto-generated domains: 'individual' (HTTP-01 per site) or 'wildcard' (pre-existing wildcard cert)
+  # Individual mode creates a Certificate per site using HTTP-01 challenge.
+  # Wildcard mode references a pre-existing wildcard certificate (requires DNS-01 setup externally).
+  pagesTlsMode: "individual"
+
+  # -- Secret name for wildcard certificate (only used when pagesTlsMode=wildcard)
+  # This must be a pre-existing secret containing a wildcard cert for *.pagesDomain
+  pagesWildcardSecret: "pages-wildcard-tls"
+
   # -- Metrics bind address
   metricsBindAddress: ":8080"
 


### PR DESCRIPTION
## Summary

- Add configurable TLS mode for auto-generated domains (sites without custom `spec.domain`)
- `individual` mode (default): Creates a Certificate per site using HTTP-01 challenge
- `wildcard` mode: References pre-existing wildcard certificate (requires external DNS-01 setup)
- Add `--pages-tls-mode` and `--pages-wildcard-secret` flags to operator
- Add `operator.pagesTlsMode` and `operator.pagesWildcardSecret` Helm values

## Test plan

- [x] Go unit tests pass (`go test ./...`)
- [x] Helm unit tests pass (`helm unittest charts/kup6s-pages`)
- [x] Linting passes (`make lint`)
- [ ] Manual test: Deploy with `pagesTlsMode=individual`, verify Certificate is created for auto-generated domain
- [ ] Manual test: Deploy with `pagesTlsMode=wildcard`, verify no Certificate is created and wildcard secret is referenced

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)