### PR TITLE
docs: add TLS mode configuration to documentation

### DIFF
--- a/docs/content/reference/cli-flags.md
+++ b/docs/content/reference/cli-flags.md
@@ -15,8 +15,19 @@ Command-line flags for the operator and syncer components.
 | `--cluster-issuer` | `letsencrypt-prod` | cert-manager ClusterIssuer name |
 | `--nginx-namespace` | `kup6s-pages` | Namespace where nginx service runs |
 | `--nginx-service-name` | `kup6s-pages-nginx` | Name of the nginx service |
+| `--pages-tls-mode` | `individual` | TLS mode for auto-generated domains: `individual` or `wildcard` |
+| `--pages-wildcard-secret` | `pages-wildcard-tls` | Secret name for wildcard certificate (only used with `--pages-tls-mode=wildcard`) |
 | `--metrics-bind-address` | `:8080` | Metrics endpoint |
 | `--health-probe-bind-address` | `:8081` | Health probe endpoint |
+
+### TLS Modes
+
+| Mode | Description |
+|------|-------------|
+| `individual` | Creates a Certificate per site using HTTP-01 challenge. Works without DNS provider API access. |
+| `wildcard` | References a pre-existing wildcard certificate. Requires external DNS-01 setup for wildcard cert issuance. |
+
+> **Note:** Wildcard mode requires a pre-existing `*.{pagesDomain}` certificate. This must be created externally using DNS-01 challenge, as Let's Encrypt doesn't support wildcard certs via HTTP-01.
 
 ### Example
 
@@ -25,7 +36,8 @@ go run ./cmd/operator \
   --pages-domain=pages.example.com \
   --cluster-issuer=letsencrypt-prod \
   --nginx-namespace=kup6s-pages \
-  --nginx-service-name=kup6s-pages-nginx
+  --nginx-service-name=kup6s-pages-nginx \
+  --pages-tls-mode=individual
 ```
 
 ## Syncer Flags

--- a/docs/content/reference/helm-values.md
+++ b/docs/content/reference/helm-values.md
@@ -35,6 +35,8 @@ Complete reference for all Helm chart configuration options.
 | `operator.image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `operator.pagesDomain` | `pages.kup6s.com` | Pages domain for auto-generated site URLs |
 | `operator.clusterIssuer` | `letsencrypt-prod` | cert-manager ClusterIssuer name |
+| `operator.pagesTlsMode` | `individual` | TLS mode for auto-generated domains: `individual` (HTTP-01 per site) or `wildcard` (pre-existing wildcard cert) |
+| `operator.pagesWildcardSecret` | `pages-wildcard-tls` | Secret name for wildcard certificate (only used when `pagesTlsMode=wildcard`) |
 | `operator.metricsBindAddress` | `:8080` | Metrics bind address |
 | `operator.healthProbeBindAddress` | `:8081` | Health probe bind address |
 | `operator.extraArgs` | `[]` | Additional CLI arguments |


### PR DESCRIPTION
## Summary

- Add `pagesTlsMode` and `pagesWildcardSecret` to Helm values documentation
- Add `--pages-tls-mode` and `--pages-wildcard-secret` to CLI flags documentation
- Add TLS modes explanation table with note about wildcard requirements

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)