### PR TITLE
feat: add Artifact Hub annotations to Helm chart

### DIFF
--- a/charts/kup6s-pages/Chart.yaml
+++ b/charts/kup6s-pages/Chart.yaml
@@ -16,3 +16,19 @@ keywords:
 maintainers:
   - name: kup6s
     url: https://kup6s.com
+annotations:
+  artifacthub.io/license: EUPL-1.2
+  artifacthub.io/operator: "true"
+  artifacthub.io/operatorCapabilities: Basic Install
+  artifacthub.io/category: integration-delivery
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://pages-docs.sites.kup6s.com
+    - name: Support
+      url: https://github.com/kup6s/pages/issues
+  artifacthub.io/crds: |
+    - kind: StaticSite
+      version: v1alpha1
+      name: staticsites.pages.kup6s.com
+      displayName: Static Site
+      description: Defines a static website to be hosted on the cluster


### PR DESCRIPTION
## Summary
- Add Artifact Hub annotations to Chart.yaml for discoverability on artifacthub.io
- Includes license, operator metadata, CRD info, and documentation links

## What's Added
```yaml
annotations:
  artifacthub.io/license: EUPL-1.2
  artifacthub.io/operator: "true"
  artifacthub.io/operatorCapabilities: Basic Install
  artifacthub.io/category: integration-delivery
  artifacthub.io/links: [Documentation, Support]
  artifacthub.io/crds: [StaticSite]
```

## Next Steps (Manual)
After merging and releasing:
1. Register repository on https://artifacthub.io
2. URL: `oci://ghcr.io/kup6s/kup6s-pages`

## Test plan
- [x] `make lint` passes
- [ ] Helm lint validates Chart.yaml
- [ ] After release, chart is indexed on Artifact Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)