### PR TITLE
feat: add copyright notices

### DIFF
--- a/charts/kup6s-pages/Chart.yaml
+++ b/charts/kup6s-pages/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - traefik
 maintainers:
   - name: Klein & Partner KG
-    url: https://kup6s.com
+    url: https://kleinundpartner.at
 annotations:
   artifacthub.io/license: EUPL-1.2
   artifacthub.io/operator: "true"

--- a/docs/layouts/partials/docs/inject/footer.html
+++ b/docs/layouts/partials/docs/inject/footer.html
@@ -2,5 +2,5 @@
 <p style="text-align: center; font-size: 0.85em; color: var(--gray-500);">
   {{ with .Site.Data.build }}Version {{ .version }} | Built {{ .date }}{{ end }}
   <br />
-  Copyright 2025 Klein &amp; Partner KG, Völs, Austria and contributors
+  Copyright 2026 Klein &amp; Partner KG, Völs, Austria and contributors
 </p>


### PR DESCRIPTION
## Summary

Add copyright notice to documentation and Helm chart.

## Changes

- **Docs footer**: Added `Copyright 2025 Klein & Partner KG, Völs, Austria and contributors`
- **Chart.yaml**: Updated maintainer name from `kup6s` to `Klein & Partner KG`

## Test plan

- [ ] Verify docs footer displays copyright after merge
- [ ] Verify Chart.yaml passes helm lint

Fixes #119