### PR TITLE
docs(chart): add CRD examples for Artifact Hub

### DIFF
--- a/charts/kup6s-pages/Chart.yaml
+++ b/charts/kup6s-pages/Chart.yaml
@@ -40,3 +40,20 @@ annotations:
       name: staticsites.pages.kup6s.com
       displayName: Static Site
       description: Defines a static website to be hosted on the cluster
+  artifacthub.io/crdsExamples: |
+    - apiVersion: pages.kup6s.com/v1beta1
+      kind: StaticSite
+      metadata:
+        name: my-docs
+      spec:
+        repo: https://github.com/example/docs.git
+        branch: main
+        path: /public
+    - apiVersion: pages.kup6s.com/v1beta1
+      kind: StaticSite
+      metadata:
+        name: company-site
+      spec:
+        repo: https://github.com/example/website.git
+        domain: www.example.com
+        syncInterval: 10m


### PR DESCRIPTION
## Summary

Add `artifacthub.io/crdsExamples` annotation to show example StaticSite resources in Artifact Hub CRD view.

Two examples included:
1. Basic public repo with custom build path
2. Custom domain with longer sync interval

## Test plan

- [x] `make lint` passes
- [x] `helm unittest` passes
- [ ] Verify examples appear in Artifact Hub after release